### PR TITLE
fix: allow underscores in domain labels

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -41,7 +41,7 @@ export class DnsClient {
    * - Start/end dots
    * - Overall length (max 253 characters)
    * - Label length (max 63 characters)
-   * - Valid characters (a-z, 0-9, -)
+   * - Valid characters (a-z, 0-9, -, _)
    *
    * @param domain - The domain name to validate
    * @throws {Error} If the domain name is invalid
@@ -70,7 +70,7 @@ export class DnsClient {
       }
 
       // Check label characters
-      if (!/^[a-z0-9-]+$/i.test(label)) {
+      if (!/^[a-z0-9_-]+$/i.test(label)) {
         throw new Error(`Invalid characters in domain label: ${label}`)
       }
     }

--- a/test/dnsx.test.ts
+++ b/test/dnsx.test.ts
@@ -187,6 +187,23 @@ describe('DnsClient', () => {
       })).toThrow()
     })
 
+    it('should accept underscores in domain labels (DKIM, DMARC, SRV)', () => {
+      expect(() => new DnsClient({
+        domains: ['selector1._domainkey.example.com'],
+        type: 'TXT',
+      })).not.toThrow()
+
+      expect(() => new DnsClient({
+        domains: ['_dmarc.example.com'],
+        type: 'TXT',
+      })).not.toThrow()
+
+      expect(() => new DnsClient({
+        domains: ['_sip._tcp.example.com'],
+        type: 'SRV',
+      })).not.toThrow()
+    })
+
     it('should handle invalid record types', () => {
       expect(() => new DnsClient({
         domains: ['example.com'],


### PR DESCRIPTION
Fixes #2056

The domain validation regex rejects underscores, preventing queries for DKIM, DMARC, SRV, and TLSA records which use underscore-prefixed labels (e.g., `_dmarc.example.com`, `selector1._domainkey.example.com`).

One-character fix: `[a-z0-9-]` → `[a-z0-9_-]` in `validateDomainName`.

Per RFC 2181 §11, any binary label up to 63 octets is valid in DNS. The no-underscore restriction is a hostname convention (RFC 952), not a DNS protocol requirement.

Added test covering DKIM, DMARC, and SRV domain patterns.